### PR TITLE
Allow use of different core name, fixes #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## What is this?
 
-This repository allows you to quickly install Apache Solr for Drupal 9 into a [Ddev](https://ddev.readthedocs.io) project using just `ddev get drud/ddev-drupal9-solr`. It follows the [Setting up Solr (single core) - the classic way](https://git.drupalcode.org/project/search_api_solr/-/blob/4.x/README.md#setting-up-solr-single-core-the-classic-way) recipe.
+This repository allows you to quickly install Apache Solr for Drupal 9+ into a [Ddev](https://ddev.readthedocs.io) project using just `ddev get drud/ddev-drupal9-solr`. It follows the [Setting up Solr (single core) - the classic way](https://git.drupalcode.org/project/search_api_solr/-/blob/4.x/README.md#setting-up-solr-single-core-the-classic-way) recipe.
 
-## Installation on Drupal 9
+## Installation on Drupal 9+
 
 1. `ddev get drud/ddev-drupal9-solr && ddev restart`
 1. You may need to install the relevant Drupal requirements: `ddev composer require drush/drush:* drupal/search_api_solr`
@@ -24,7 +24,7 @@ This repository allows you to quickly install Apache Solr for Drupal 9 into a [D
 This is the classic Drupal solr:8 recipe used for a long time by Drupal users and compatible with search_api_solr. 
 
 * It installs a [`.ddev/docker-compose.solr.yaml`](docker-compose.solr.yaml) using the solr:8 docker image.
-* A standard Drupal 9 solr configuration is included in [.ddev/solr/conf](solr/conf).
+* A standard Drupal 9+ solr configuration is included in [.ddev/solr/conf](solr/conf).
 * A [.ddev/docker-entrypoint-initdb.d/solr-configupdate.sh](solr/docker-entrypoint-initdb.d/solr-configupdate.sh) is included and mounted into the solr container so that you can change solr config in .ddev/solr/conf with just a `ddev restart`.
 
 ## Interacting with Apache Solr
@@ -32,6 +32,13 @@ This is the classic Drupal solr:8 recipe used for a long time by Drupal users an
 * The Solr admin interface will be accessible at: `http://<projectname>.ddev.site:8983/solr/` For example, if the project is named `myproject` the hostname will be: `http://myproject.ddev.site:8983/solr/`.
 * To access the Solr container from inside the web container use: `http://solr:8983/solr/`
 * A Solr core is automatically created by default with the name "dev"; it can be accessed (from inside the web container) at the URL: `http://solr:8983/solr/dev` or from the host at `http://<projectname>.ddev.site:8983/solr/#/~cores/dev`. You can obviously create other cores to meet your needs.
+
+## Alternate Core Name
+
+If you want to use a core name other than the default "dev", edit `docker-compose.solr.yaml` to 
+1. Remove the #ddev-generated at the top of the file.
+2. Change SOLR_CORE environment variable in the `environment:` section.
+3. Change your Drupal configuration to use the new core.
 
 ## Caveats
 * This recipe won't work with versions of solr before solr:8, and Acquia and Pantheon.io hosting require versions from 3 to 7. You'll want to see the [contributed recipes](https://github.com/drud/ddev-contrib) for older versions of solr.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This repository allows you to quickly install Apache Solr for Drupal 9+ into a [
 This is the classic Drupal `solr:8` image recipe used for a long time by Drupal users and compatible with `search_api_solr`. 
 
 * It installs a [`.ddev/docker-compose.solr.yaml`](docker-compose.solr.yaml) using the solr:8 docker image.
-* A standard Drupal 9+ solr configuration is included in [.ddev/solr/conf](solr/conf).
+* A standard Drupal 9+ Solr configuration is included in [.ddev/solr/conf](solr/conf).
 * A [.ddev/docker-entrypoint-initdb.d/solr-configupdate.sh](solr/docker-entrypoint-initdb.d/solr-configupdate.sh) is included and mounted into the Solr container so that you can change Solr config in `.ddev/solr/conf` with just a `ddev restart`.
 
 ## Interacting with Apache Solr

--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ This is the classic Drupal `solr:8` image recipe used for a long time by Drupal 
 
 ## Alternate Core Name
 
-If you want to use a core name other than the default "dev", edit `docker-compose.solr.yaml` to 
+If you want to use a core name other than the default "dev", add a `.ddev/docker-compose.solr-env.yaml` with these contents, using the core name you want to use:
+```
+services:
+  solr:
+    environment:
+    - SOLR_CORENAME=somecorename
+```
 1. Remove the #ddev-generated at the top of the file.
 2. Change SOLR_CORE environment variable in the `environment:` section.
 3. Change your Drupal configuration to use the new core.

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ This repository allows you to quickly install Apache Solr for Drupal 9+ into a [
 
 ## Explanation
 
-This is the classic Drupal solr:8 recipe used for a long time by Drupal users and compatible with search_api_solr. 
+This is the classic Drupal `solr:8` image recipe used for a long time by Drupal users and compatible with `search_api_solr`. 
 
 * It installs a [`.ddev/docker-compose.solr.yaml`](docker-compose.solr.yaml) using the solr:8 docker image.
 * A standard Drupal 9+ solr configuration is included in [.ddev/solr/conf](solr/conf).
-* A [.ddev/docker-entrypoint-initdb.d/solr-configupdate.sh](solr/docker-entrypoint-initdb.d/solr-configupdate.sh) is included and mounted into the solr container so that you can change solr config in .ddev/solr/conf with just a `ddev restart`.
+* A [.ddev/docker-entrypoint-initdb.d/solr-configupdate.sh](solr/docker-entrypoint-initdb.d/solr-configupdate.sh) is included and mounted into the Solr container so that you can change Solr config in `.ddev/solr/conf` with just a `ddev restart`.
 
 ## Interacting with Apache Solr
 
@@ -41,6 +41,6 @@ If you want to use a core name other than the default "dev", edit `docker-compos
 3. Change your Drupal configuration to use the new core.
 
 ## Caveats
-* This recipe won't work with versions of solr before solr:8, and Acquia and Pantheon.io hosting require versions from 3 to 7. You'll want to see the [contributed recipes](https://github.com/drud/ddev-contrib) for older versions of solr.
+* This recipe won't work with versions of Solr before `solr:8`, and Acquia and Pantheon.io hosting require versions from 3 to 7. You'll want to see the [contributed recipes](https://github.com/drud/ddev-contrib) for older versions of solr.
 
 

--- a/docker-compose.solr.yaml
+++ b/docker-compose.solr.yaml
@@ -1,4 +1,4 @@
-# DDev Apache Solr recipe file.
+# DDEV Apache Solr recipe file.
 #ddev-generated
 #
 #
@@ -43,6 +43,9 @@ services:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
     environment:
+      # If you want to use a different name for the core created, change SOLR_CORENAME
+      # and remove the ddev-generated from the top of this file
+      - SOLR_CORENAME=dev
       # This defines the host name the service should be accessible from. This
       # will be sitename.ddev.site.
       - VIRTUAL_HOST=$DDEV_HOSTNAME
@@ -70,7 +73,9 @@ services:
       # `chmod +x solr
       - "./solr/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d"
 
-    entrypoint: [ "sh", "-c", "docker-entrypoint.sh solr-precreate dev /solr-conf" ]
+    # The odd need to use $$SOLR_CORENAME here is explained in
+    # https://stackoverflow.com/a/48189916/215713
+    entrypoint:  'bash -c "VERBOSE=yes docker-entrypoint.sh solr-precreate $${SOLR_CORENAME:-dev} /solr-conf"'
 
     external_links:
       - "ddev-router:${DDEV_SITENAME}.${DDEV_TLD}"

--- a/docker-compose.solr.yaml
+++ b/docker-compose.solr.yaml
@@ -23,8 +23,6 @@
 #   accessed at the URL: http://solr:8983/solr/dev (inside web container)
 #   or at http://myproject.ddev.site:8983/solr/dev (on the host)
 
-version: '3.6'
-
 services:
   solr:
     # Name of container using standard ddev convention
@@ -43,9 +41,6 @@ services:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
     environment:
-      # If you want to use a different name for the core created, change SOLR_CORENAME
-      # and remove the ddev-generated from the top of this file
-      - SOLR_CORENAME=dev
       # This defines the host name the service should be accessible from. This
       # will be sitename.ddev.site.
       - VIRTUAL_HOST=$DDEV_HOSTNAME

--- a/install.yaml
+++ b/install.yaml
@@ -4,7 +4,8 @@ pre_install_actions:
 
 # files and directories listed here are copied into .ddev
 project_files:
-- solr
+- solr/conf
+- solr/docker-entrypoint-initdb.d/solr-configupdate.sh
 - docker-compose.solr.yaml
 
 post_install_actions:

--- a/solr/docker-entrypoint-initdb.d/solr-configupdate.sh
+++ b/solr/docker-entrypoint-initdb.d/solr-configupdate.sh
@@ -2,10 +2,10 @@
 #ddev-generated
 set -e
 
-# Ensure "dev" core config is always up to date even after the
+# Ensure "dev" (or alternate SOLR_CORENAME) core config is always up to date even after the
 # core has been created. This does not execute the first time,
 # when solr-precreate has not yet run.
-CORENAME=dev
+CORENAME=${SOLR_CORENAME:-dev}
 if [ -d /var/solr/data/${CORENAME}/conf ]; then
     cp /solr-conf/conf/* /var/solr/data/${CORENAME}/conf
 fi


### PR DESCRIPTION
* #12 

This makes it easier to use a different core name. 

From the updated README:

If you want to use a core name other than the default "dev", edit `docker-compose.solr.yaml` to 
1. Remove the #ddev-generated at the top of the file.
2. Change SOLR_CORE environment variable in the `environment:` section.
3. Change your Drupal configuration to use the new core.

You can test this PR with `https://github.com/rfay/ddev-drupal9-solr/tarball/20221230_config_corename`