### PR TITLE
#19 - change data volume location

### DIFF
--- a/docker-compose.solr.yaml
+++ b/docker-compose.solr.yaml
@@ -51,7 +51,7 @@ services:
       # solr core *data* is stored on the 'solr' docker volume
       # This mount is optional; without it your search index disappears
       # each time the ddev project is stopped and started.
-      - solr:/var/solr
+      - solr:/opt/solr/server/solr/mycoresç
 
       # This mounts the conf in .ddev/solr into the container where
       # the solr-precreate command in the entrypoint uses it as a one-time

--- a/docker-compose.solr.yaml
+++ b/docker-compose.solr.yaml
@@ -51,7 +51,7 @@ services:
       # solr core *data* is stored on the 'solr' docker volume
       # This mount is optional; without it your search index disappears
       # each time the ddev project is stopped and started.
-      - solr:/opt/solr/server/solr/mycoresç
+      - solr:/opt/solr/server/solr/mycores
 
       # This mounts the conf in .ddev/solr into the container where
       # the solr-precreate command in the entrypoint uses it as a one-time


### PR DESCRIPTION
## The Issue

When a project is restarted, then the data is flushed. This happens when running `ddev stop` and later `ddev start` or directly using `ddev restart`.

System details:
```
 ITEM             VALUE                                   
 DDEV version     v1.21.6                                 
 architecture     amd64                                   
 db               drud/ddev-dbserver-mariadb-10.4:v1.21.5 
 dba              phpmyadmin:5                            
 ddev-ssh-agent   drud/ddev-ssh-agent:v1.21.5             
 docker           20.10.9                                 
 docker-compose   v2.15.1                                 
 docker-platform  portatil                                
 mutagen          0.16.0                                  
 os               linux                                   
 router           drud/ddev-router:v1.21.5                
 web              drud/ddev-webserver:v1.21.5 
```

Solr version: `7.7.3`

## How This PR Solves The Issue

Use the real data path

## Test issue

1. Open a existing ddev project that uses Solr
2. Index data
3. Stop/start or restart it
4. Check if data is there

## Test how this PR fix the problem

Repeat the same steps used for test the issue but with the line changed, data should stay there




