### PR TITLE
Update link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository allows you to quickly install Apache Solr for Drupal 9+ into a [
 
 ### Other frameworks
 
-See [the documentation in the `docs` folder](docs/README.md)
+See [the documentation in the `doc` folder](doc/README.md)
 
 ## Explanation
 


### PR DESCRIPTION
I named the links "docs"
And the actual folder "doc"

This fixes the links, because it's historically easier to do so, despite that technically the doc folder should semantically be named the plural, because it's hopefully going to contain multiple doc
