### PR TITLE
Improve README about Pantheon/Acquia requirements for solr

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ services:
 
 ## Caveats
 
-* This recipe won't work with versions of Solr before `solr:8`, and Acquia's hosting require versions from 3 to 7. You'll want to see the [contributed recipes](https://github.com/ddev/ddev-contrib) for older versions of solr.
+* This recipe won't work with versions of Solr before `solr:8`, and Acquia's hosting requires versions from 3 to 7. You'll want to see the [contributed recipes](https://github.com/ddev/ddev-contrib) for older versions of solr.

--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ services:
 
 ## Caveats
 
-* This recipe won't work with versions of Solr before `solr:8`, and Acquia and Pantheon.io hosting require versions from 3 to 7. You'll want to see the [contributed recipes](https://github.com/ddev/ddev-contrib) for older versions of solr.
+* This recipe won't work with versions of Solr before `solr:8`, and Acquia's hosting require versions from 3 to 7. You'll want to see the [contributed recipes](https://github.com/ddev/ddev-contrib) for older versions of solr.

--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ services:
 
 ## Caveats
 
-* This recipe won't work with versions of Solr before `solr:8`, and Acquia's hosting requires versions from 3 to 7. You'll want to see the [contributed recipes](https://github.com/ddev/ddev-contrib) for older versions of solr.
+* This recipe won't work with versions of Solr before `solr:8`, and Acquia's hosting requires Solr 7. You'll want to see the [contributed recipes](https://github.com/ddev/ddev-contrib) for older versions of Solr.


### PR DESCRIPTION
Removing Caveat language. Pantheon support Solr8 as a default for all sites Drupal8+ as of 2021.

## The Issue
Caveat language is out of date.

## How This PR Solves The Issue
Removes explicit Pantheon language as this is no longer the case. 

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
No.. Just a README.md change. 
