### PR TITLE
add link to Acquia docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ services:
 
 ## Caveats
 
-* This recipe won't work with versions of Solr before `solr:8`, and Acquia's hosting requires Solr 7. You'll want to see the [contributed recipes](https://github.com/ddev/ddev-contrib) for older versions of Solr.
+* This recipe won't work with versions of Solr before `solr:8`, and Acquia's hosting [requires Solr 7](https://docs.acquia.com/acquia-search/). You'll want to see the [contributed recipes](https://github.com/ddev/ddev-contrib) for older versions of Solr.


### PR DESCRIPTION
This PR adds a link to Acquia documention where they state the required Solr version.