### PR TITLE
Use Solr Slim branch

### DIFF
--- a/docker-compose.solr.yaml
+++ b/docker-compose.solr.yaml
@@ -31,7 +31,7 @@ services:
     # and code at https://github.com/docker-solr/docker-solr
     # README: https://github.com/docker-solr/docker-solr/blob/master/README.md
     # It's almost impossible to work with it if you don't read the docs there
-    image: solr:8
+    image: solr:8-slim
     restart: "no"
     # Solr is served from this port inside the container.
     expose:


### PR DESCRIPTION
The official docker/solr containers have a slim tag.
Since we only use Solr for solr, i don't see a reason why we use the bloated version.

The slim verison is smaller and faster to boot.
> Unless you are working in an environment where only the solr image will be deployed and you have space constraints, we highly recommend using the default image of this repository
[- source](https://hub.docker.com/_/solr#:~:text=Unless%20you%20are%20working%20in%20an%20environment%20where%20only%20the%20solr%20image%20will%20be%20deployed%20and%20you%20have%20space%20constraints%2C%20we%20highly%20recommend%20using%20the%20default%20image%20of%20this%20repository) 