### PR TITLE
Solr admin not acessible on HTTPS

### DIFF
--- a/docker-compose.solr.yaml
+++ b/docker-compose.solr.yaml
@@ -47,6 +47,7 @@ services:
       # HTTP_EXPOSE exposes http traffic from the container port 8983
       # to the host port 8983 vid ddev-router reverse proxy.
       - HTTP_EXPOSE=8983:8983
+      - HTTPS_EXPOSE=8983:8983
     volumes:
       # solr core *data* is stored on the 'solr' docker volume
       # This mount is optional; without it your search index disappears


### PR DESCRIPTION
## The Issue

If you follow the instructions to open the Solr Admin via HTTP (http://.ddev.site:8983/solr/) you are redirect automatically to HTTPS and that doesn't work.

## How This PR Solves The Issue

Have the Solr Admin available also on HTTPS.

HTTPS_EXPOSE=8983:8983

## Related Issue Link(s)

https://github.com/ddev/ddev-drupal9-solr/issues/33



