### PR TITLE
feat: upgrade to Solr 9, fixes #48

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ See [the documentation in the `doc` folder](doc/README.md)
 
 This originates from the classic Drupal `solr:8` image recipe used for a long time by Drupal users and compatible with `search_api_solr`.
 
-* It installs a [`.ddev/docker-compose.solr.yaml`](docker-compose.solr.yaml) using the `solr:8` docker image.
+* It installs a [`.ddev/docker-compose.solr.yaml`](docker-compose.solr.yaml) using the `solr:9` docker image.
 * A standard Drupal 9+ Solr configuration is included in [.ddev/solr/conf](solr/conf).
 * A [.ddev/docker-entrypoint-initdb.d/solr-configupdate.sh](solr/docker-entrypoint-initdb.d/solr-configupdate.sh) is included and mounted into the Solr container so that you can change Solr config in `.ddev/solr/conf` with just a `ddev restart`.
 

--- a/docker-compose.solr.yaml
+++ b/docker-compose.solr.yaml
@@ -42,7 +42,7 @@ services:
         RUN sed -i '/X-Forwarded-/,/-->/ {/<!--/d; /-->/d}' /opt/solr/server/etc/jetty.xml
         USER solr
       args:
-        SOLR_BASE_IMAGE: ${SOLR_BASE_IMAGE:-solr:8}
+        SOLR_BASE_IMAGE: ${SOLR_BASE_IMAGE:-solr:9}
     restart: "no"
     # Solr is served from this port inside the container.
     expose:


### PR DESCRIPTION
## The Issue

- #48

SOLR 8 is EOL

## How This PR Solves The Issue

Upgrades to SOLR 9

## Manual Testing Instructions

```
ddev add-on get https://github.com/ddev/ddev-drupal-solr/tarball/solr9
ddev restart
ddev launch :8943
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

- https://solr.apache.org/news.html#solr-8-reaches-end-of-life

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

