### PR TITLE
feat: support HTTPS for Solr Admin, fixes #33

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This add-on integrates Solr for Drupal 9+ into your [DDEV](https://ddev.com/) pr
      * Under "Advanced server configuration" set the "solr.install.dir" to `/opt/solr`.
 6. `ddev restart`
 
-## Outdated Solr config files
+### Outdated Solr config files
 
 If you get a message about Solr having outdated config files, you need to update the included Solr config files.
 
@@ -46,6 +46,15 @@ If you get a message about Solr having outdated config files, you need to update
 
 See [the documentation in the `doc` folder](doc/README.md)
 
+## Usage
+
+| Command | Description |
+| ------- | ----------- |
+| `ddev launch :8943` | Open Solr Admin (HTTPS) in your browser (`https://<project>.ddev.site:8943`) |
+| `ddev launch :8983` | Open Solr Admin (HTTP) in your browser (`http://<project>.ddev.site:8983`) |
+| `ddev describe` | View service status and used ports for Solr |
+| `ddev logs -s solr` | Check Solr logs |
+
 ## Explanation
 
 This is the classic Drupal `solr:8` image recipe used for a long time by Drupal users and compatible with `search_api_solr`.
@@ -56,9 +65,9 @@ This is the classic Drupal `solr:8` image recipe used for a long time by Drupal 
 
 ## Interacting with Apache Solr
 
-* The Solr admin interface will be accessible at: `http://<projectname>.ddev.site:8983/solr/` For example, if the project is named `myproject` the hostname will be: `http://myproject.ddev.site:8983/solr/`.
+* The Solr Admin interface will be accessible at: `https://<projectname>.ddev.site:8943/solr/` and `http://<projectname>.ddev.site:8983/solr/`. For example, if the project is named `myproject` the hostname will be: `https://myproject.ddev.site:8943/solr/`.
 * To access the Solr container from inside the web container use: `http://solr:8983/solr/`
-* A Solr core is automatically created by default with the name "dev"; it can be accessed (from inside the web container) at the URL: `http://solr:8983/solr/dev` or from the host at `http://<projectname>.ddev.site:8983/solr/#/~cores/dev`. You can obviously create other cores to meet your needs.
+* A Solr core is automatically created by default with the name "dev"; it can be accessed (from inside the web container) at the URL: `http://solr:8983/solr/dev` or from the host at `https://<projectname>.ddev.site:8943/solr/#/~cores/dev`. You can obviously create other cores to meet your needs.
 
 ## Alternate Core Name
 
@@ -74,7 +83,7 @@ services:
 1. Change `SOLR_CORENAME` environment variable in the `environment:` section.
 2. Change your Drupal configuration to use the new core.
 
-You can delete the "dev" core from `http://<projectname>.ddev.site:8983/solr/#/~cores/dev` by clicking "Unload".
+You can delete the "dev" core from `https://<projectname>.ddev.site:8943/solr/#/~cores/dev` by clicking "Unload".
 
 ## Multiple Solr Cores
 

--- a/docker-compose.solr.yaml
+++ b/docker-compose.solr.yaml
@@ -31,7 +31,18 @@ services:
     # and code at https://github.com/docker-solr/docker-solr
     # README: https://github.com/docker-solr/docker-solr/blob/master/README.md
     # It's almost impossible to work with it if you don't read the docs there
-    image: solr:8
+    build:
+      dockerfile_inline: |
+        ARG SOLR_BASE_IMAGE="scratch"
+        FROM $$SOLR_BASE_IMAGE
+        # Fix HTTPS redirect to HTTP which breaks URL for Solr Admin UI.
+        # The reason for this problem is that Solr uses Jetty as a webserver.
+        # Jetty has X-Forwarded- headers disabled by default, enable them here:
+        USER root
+        RUN sed -i '/X-Forwarded-/,/-->/ {/<!--/d; /-->/d}' /opt/solr/server/etc/jetty.xml
+        USER solr
+      args:
+        SOLR_BASE_IMAGE: ${SOLR_BASE_IMAGE:-solr:8}
     restart: "no"
     # Solr is served from this port inside the container.
     expose:
@@ -39,7 +50,7 @@ services:
     # These labels ensure this service is discoverable by ddev.
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT
+      com.ddev.approot: ${DDEV_APPROOT}
     environment:
       # This defines the host name the service should be accessible from. This
       # will be sitename.ddev.site.
@@ -47,6 +58,7 @@ services:
       # HTTP_EXPOSE exposes http traffic from the container port 8983
       # to the host port 8983 vid ddev-router reverse proxy.
       - HTTP_EXPOSE=8983:8983
+      - HTTPS_EXPOSE=8943:8983
     volumes:
       # solr core *data* is stored on the 'solr' docker volume
       # This mount is optional; without it your search index disappears
@@ -60,6 +72,7 @@ services:
       - ./solr:/solr-conf
 
       - ".:/mnt/ddev_config"
+      - ddev-global-cache:/mnt/ddev-global-cache
 
       # solr-configupdate.sh copies fresh configuration files into the
       # solr container on each
@@ -70,7 +83,7 @@ services:
 
     # The odd need to use $$SOLR_CORENAME here is explained in
     # https://stackoverflow.com/a/48189916/215713
-    entrypoint:  'bash -c "VERBOSE=yes docker-entrypoint.sh solr-precreate $${SOLR_CORENAME:-dev} /solr-conf"'
+    entrypoint: 'bash -c "VERBOSE=yes docker-entrypoint.sh solr-precreate $${SOLR_CORENAME:-dev} /solr-conf"'
 
     external_links:
       - "ddev-router:${DDEV_SITENAME}.${DDEV_TLD}"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -52,6 +52,23 @@ health_checks() {
 
   run ddev drush search-api-solr:reload default_solr_server
   assert_success
+
+  # Make sure the solr admin UI via HTTP from outside is redirected to HTTP /solr/
+  run curl -sfI http://${PROJNAME}.ddev.site:8983
+  assert_success
+  assert_output --partial "HTTP/1.1 302"
+  assert_output --partial "Location: http://${PROJNAME}.ddev.site:8983/solr/"
+
+  # Make sure the solr admin UI via HTTPS from outside is redirected to HTTPS /solr/
+  run curl -sfI https://${PROJNAME}.ddev.site:8943
+  assert_success
+  assert_output --partial "HTTP/2 302"
+  assert_output --partial "location: https://${PROJNAME}.ddev.site:8943/solr/"
+
+  # Make sure the solr admin UI is working from outside
+  run curl -sfL https://${PROJNAME}.ddev.site:8943
+  assert_success
+  assert_output --partial "Solr Admin"
 }
 
 teardown() {


### PR DESCRIPTION
## The Issue

- #33

## How This PR Solves The Issue

Uses the same technique I implemented in `ddev-solr`.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-drupal-solr/tarball/20250424_stasadev_solr_admin_https
ddev restart
ddev launch :8943
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
